### PR TITLE
Attachment NilClass handled gracefully

### DIFF
--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -7,6 +7,8 @@ Spree::Image.class_eval do
   def destroy_attached_files; end
 
   def attachment_file_name
-    attachment.file.filename
+  	# spree_cloudinary bug, NilClass
+    # attachment.file.filename
+    "not_blank" # from original spree_cloudinary
   end
 end

--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -7,8 +7,7 @@ Spree::Image.class_eval do
   def destroy_attached_files; end
 
   def attachment_file_name
-  	# spree_cloudinary bug, NilClass
-    # attachment.file.filename
-    "not_blank" # from original spree_cloudinary
+  	# handle NilClass gracefully
+    attachment.file.nil? ? "" : attachment.file.filename
   end
 end


### PR DESCRIPTION
Reverting image decorator back to chautoni/spree_cloudinary behaviour due to bug found in current codebase.